### PR TITLE
Complete making JustSayIt portable and add keyword for custom audio input stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Saying "help <command name>" shows the help of one of the available commands. He
 Saying "sleep JustSayIt" puts JustSayIt to sleep. It will not execute any commands until it is awoken with the words "awake JustSayIt".
 
 ## Dependencies
-JustSayIt's primary dependencies are [Vosk], [Pynput], [PyCall.jl], [Conda.jl] and [MacroTools.jl].
+JustSayIt's primary dependencies are [vosk], [sounddevice], [pynput], [PyCall.jl], [Conda.jl] and [MacroTools.jl].
 
 ## Installation
 JustSayIt can be installed directly with the [Julia package manager](https://docs.julialang.org/en/v1/stdlib/Pkg/index.html) from the REPL:
@@ -150,6 +150,7 @@ This project needs your contribution! There are a lot of commands for all differ
 [Julia REPL]: https://docs.julialang.org/en/v1/stdlib/REPL/
 [MacroTools.jl]: https://github.com/FluxML/MacroTools.jl
 [PyCall.jl]: https://github.com/JuliaPy/PyCall.jl
-[Pynput]: https://github.com/moses-palmer/pynput
-[Vosk]: https://github.com/alphacep/vosk-api
+[pynput]: https://github.com/moses-palmer/pynput
+[sounddevice]: https://github.com/spatialaudio/python-sounddevice
+[vosk]: https://github.com/alphacep/vosk-api
 [Vosk Speech Recognition Toolkit]: https://alphacephei.com/vosk/

--- a/README.md
+++ b/README.md
@@ -1,24 +1,98 @@
 # JustSayIt
 
-JustSayIt enables offline, low latency, highly accurate speech to command translation and is usable as software or API. It implements a **novel algorithm for high performance context dependent recognition of spoken commands** which leverages the [Vosk Speech Recognition Toolkit]. Single word commands' latency (referring to the time elapsed between a command is spoken and executed) can be little as 5 miliseconds and does usually not exceed 30 miliseconds (measured on a regular notebook).
+JustSayIt enables offline, low latency, highly accurate and secure speech to command translation on Linux, MacOS and Windows and is usable as software or API. It implements a **novel algorithm for high performance context dependent recognition of spoken commands** which leverages the [Vosk Speech Recognition Toolkit]. Single word commands' latency (referring to the time elapsed between a command is spoken and executed) can be little as 5 miliseconds and does usually not exceed 30 miliseconds (measured on a regular notebook).
 
 Furthermore, JustSayIt provides an **unprecedented highly generic extension to the Julia programming language which allows to declare arguments in standard function definitions to be obtainable by voice**. For such functions, JustSayIt automatically generates a wrapper method that takes care of the complexity of retrieving the arguments from the speakers voice, including interpretation and conversion of the voice arguments to potentially any data type. JustSayIt commands are implemented with such *voice argument functions*, triggered by a user definable mapping of command names to functions. As a result, it empowers programmers without any knowledge of speech recognition to quickly write new commands that take their arguments from the speakers voice. **JustSayIt is ideally suited for development by the world-wide open source community**.
 
-**JustSayIt unites the advantages of Julia and Python**: it leverages Julia's performance and metaprogramming capabilities and Python's large ecosystem where no suitable Julia package is found - PyCall.jl makes calling Python packages from Julia trivial. JustSayIt embraces the vision "Why choose between Julia or Python? - Use both!".
+**JustSayIt unites the advantages of Julia and Python**: it leverages Julia's performance and metaprogramming capabilities and Python's larger ecosystem where no suitable Julia package is found - PyCall.jl makes calling Python packages from Julia trivial. JustSayIt embraces the vision "Why choose between Julia or Python? - Use both!".
 
 Finally, JustSayIt puts a small load on the CPU, using only one core, and can therefore run continuously without harming the computer usage experience.
 
 ## Contents
-* [Voice argument functions](#voice-argument-functions)
-* [Module documentation callable from the Julia REPL / IJulia](#module-documentation-callable-from-the-julia-repl--ijulia)
+* [Quick start](#quick-start)
+* [User definable mapping of command names to functions](user-definable-mapping-of-command-names-to-functions)
 * [Help on commands callable by voice](#help-on-commands-callable-by-voice)
 * [Sleep and wake up by voice](#sleep-and-wake-up-by-voice)
-* [Dependencies](#dependencies)
-* [Installation](#installation)
+* [Fast command programming with voice argument functions](#fast-command-programming-with-voice-argument-functions)
+* [Module documentation callable from the Julia REPL / IJulia](#module-documentation-callable-from-the-julia-repl--ijulia)
+* [Fully automatic installation](#fully-automatic-installation)
+* [Support for Linux, MacOS and Windows](support-for-linux-macos-and-windows)
+* [Dependencies](#Dependencies)
 * [Your contributions](#your-contributions)
 
-## Voice argument functions
-The `@voiceargs` macro allows to declare arguments in standard function definitions to be obtainable by voice. It, furthermore, allows to define speech recognition parameters for each voice argument as, e.g., the valid speech input. The following shows some examples:
+## Quick start
+1. Install [Julia] if you do not have it yet.
+2. Execute the following in your shell to install and run JustSayIt:
+```julia-repl
+$> julia
+julia> ]
+  pkg> add https://github.com/omlins/JustSayIt
+  pkg> <backspace button>
+julia> using JustSayIt
+julia> just_say_it()
+```
+3. Say "help commands" and then, e.g., "help type".
+
+## User definable mapping of command names to functions
+The keyword `commands` of `just_say_it` enables to freely define a mapping of command names to functions, e.g.:
+```julia-repl
+# Define custom commands
+using JustSayIt
+commands = Dict("cat"    => Help.help,
+                "dog"    => Keyboard.type,
+                "mouse"  => Mouse.click_double,
+                "monkey" => Mouse.click_triple,
+                "zebra"  => Email.email,
+                "snake"  => Internet.internet)
+just_say_it(commands=commands)
+```
+
+The keyword `subset` of `just_say_it` enables to activate only a subset of the default or user-defined commands. The following example selects a subset of the default commands:
+```julia-repl
+# Listen to all default commands with exception of the mouse button commands.
+using JustSayIt
+just_say_it(subset=("help", "type", "email", "internet"))
+```
+
+More information on customization keywords is obtainable by typing `?just_say_it`.
+
+## Help on commands callable by voice
+Saying "help commands" lists your available commands in the Julia REPL leading to, e.g., the following output:
+```julia-repl
+┌ Info:
+│ Your commands:
+│ double   => click_double
+│ email    => email
+│ help     => help
+│ internet => internet
+│ ma       => click_left
+│ middle   => click_middle
+│ okay     => release_left
+│ right    => click_right
+│ select   => press_left
+│ triple   => click_triple
+└ type     => type
+```
+Saying "help <command name>" shows the help of one of the available commands. Here is, e.g., the output produced when saying "help email":
+```
+[ Info: Starting command: help (latency: 83 ms)
+┌ Info: Command email
+│    =
+│      email `inbox` | `outbox`
+│    
+│      Manage e-mails, performing one of the following actions:
+│    
+│        •  inbox
+│    
+└        •  outbox
+```
+Note that the submodules `Email` and `Internet` contain still very little functionality. Yet, they illustrate how submodules for all kind of operations can be programmed.
+
+## Sleep and wake up by voice
+Saying "sleep JustSayIt" puts JustSayIt to sleep. It will not execute any commands until it is awoken with the words "awake JustSayIt".
+
+## Fast command programming with voice argument functions
+JustSayIt commands map to regular Julia functions. Function arguments can be easily passed by voice thanks to the `@voiceargs` macro. It allows to declare arguments in standard function definitions to be directly obtainable by voice. It, furthermore, allows to define speech recognition parameters for each voice argument as, e.g., the valid speech input. The following shows some examples:
 ```julia
   @voiceargs (b, c) function f(a, b::String, c::String, d)
       #(...)
@@ -51,94 +125,24 @@ search: JustSayIt just_say_it
 
   Enables offline, low latency, highly accurate speech to command translation and is usable as software or API.
 
-  General overview and examples
-  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-
-  https://github.com/omlins/JustSayIt.jl
-
-  Software usage
-  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-
-  > julia
-  julia> using JustSayIt
-  julia> just_say_it()
-
-  Type ?just_say_it to learn about customization keywords.
-
-  Application Programming Interface (API)
-  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
-
-  Macros
-  --------
-
-    •  @voiceargs
-
-  Functions
-  -----------
-
-    •  just_say_it
-
-    •  init_jsi
-
-    •  finalize_jsi
-
-    •  is_next
-
-    •  pause_recording
-
-    •  restart_recording
-
-  Submodules
-  ------------
-
-    •  Help
-
-    •  Keyboard
-
-    •  Mouse
-
-    •  Email
-
-    •  Internet
+  (...)
 
   To see a description of a function, macro or module type ?<functionname>, ?<macroname> (including the @) or ?<modulename>, respectively.
 ```
 
-## Help on commands callable by voice
-Saying "help commands" lists your available commands in the Julia REPL leading to, e.g., the following output:
-```julia-repl
-┌ Info:
-│ Your commands:
-│ double   => click_double
-│ email    => email
-│ help     => help
-│ internet => internet
-│ ma       => click_left
-│ middle   => click_middle
-│ okay     => release_left
-│ right    => click_right
-│ select   => press_left
-│ triple   => click_triple
-└ type     => type
-```
-Saying "help <command name>" shows the help of one of the available commands. Here is, e.g., the output produced when saying "help double":
-```
-┌ Info: Command double
-└    =   Doubleclick left mouse button.
-```
-
-## Sleep and wake up by voice
-Saying "sleep JustSayIt" puts JustSayIt to sleep. It will not execute any commands until it is awoken with the words "awake JustSayIt".
-
-## Dependencies
-JustSayIt's primary dependencies are [vosk], [sounddevice], [pynput], [PyCall.jl], [Conda.jl] and [MacroTools.jl].
-
-## Installation
-JustSayIt can be installed directly with the [Julia package manager](https://docs.julialang.org/en/v1/stdlib/Pkg/index.html) from the REPL:
+## Fully automatic installation
+After installing [Julia] - if not yet installed - JustSayIt can be installed directly with the [Julia package manager](https://docs.julialang.org/en/v1/stdlib/Pkg/index.html) from the [Julia REPL]:
 ```julia-repl
 julia>]
   pkg> add https://github.com/omlins/JustSayIt
 ```
+All dependencies are automatically installed. Python dependencies are automatically installed in a local mini-conda environment, set up by [Conda.jl]. Default language models are automatically downloaded at first usage of JustSayIt.
+
+## Support for Linux, MacOS and Windows
+JustSayIt is programmed in a highly portable manner relying exclusively on portable Julia and Python modules (see [Dependencies](#dependencies)).
+
+## Dependencies
+JustSayIt's primary dependencies are [vosk], [sounddevice], [pynput], [PyCall.jl], [Conda.jl] and [MacroTools.jl].
 
 ## Your contributions
 This project needs your contribution! There are a lot of commands for all different kind of operations to be programmed! Note that pull request should always address a significant issue in its completeness and new commands should be generic enough to be of interest for others. Please open an issue to discuss the addition of new features beforehand.
@@ -147,6 +151,7 @@ This project needs your contribution! There are a lot of commands for all differ
 
 [Conda.jl]: https://github.com/JuliaPy/Conda.jl
 [IJulia]: https://github.com/JuliaLang/IJulia.jl
+[Julia]: https://julialang.org
 [Julia REPL]: https://docs.julialang.org/en/v1/stdlib/REPL/
 [MacroTools.jl]: https://github.com/FluxML/MacroTools.jl
 [PyCall.jl]: https://github.com/JuliaPy/PyCall.jl

--- a/src/Commands/Email.jl
+++ b/src/Commands/Email.jl
@@ -24,22 +24,25 @@ const EMAIL_ENGINE = "https://mail.google.com"
 ## Functions
 
 @doc """
-    email `inbox`
+    email `inbox` | `outbox`
 
 Manage e-mails, performing one of the following actions:
-    - `inbox`
+- `inbox`
+- `outbox`
 """
 email
-@enum Action inbox
+@enum Action inbox outbox
 @voiceargs action=>(valid_input_auto=true, use_max_accuracy=true) function email(action::Action)
-    if (action == inbox) open_inbox()
-    else @info "unknown action" #NOTE: this should never happen.
+    if     (action == inbox)  open_inbox()
+    elseif (action == outbox) open_outbox()
+    else                      @info "unknown action"  #NOTE: this should never happen.
     end
 end
 
-@doc "Search in internet: start search engine and automatically change to type command waiting for search keywords to be spoken."
-function open_inbox()
-    DefaultApplication.open(EMAIL_ENGINE)
-end
+@doc "Open E-mail inbox."
+open_inbox() = DefaultApplication.open(EMAIL_ENGINE)
+
+@doc "Open E-mail outbox."
+open_outbox() = DefaultApplication.open(EMAIL_ENGINE * "/" * "#sent")
 
 end # module Email

--- a/src/Commands/Internet.jl
+++ b/src/Commands/Internet.jl
@@ -27,7 +27,7 @@ const SEARCH_ENGINE = "https://google.com"
     internet `search`
 
 Navigate the internet, performing one of the following actions:
-    - `search`
+- `search`
 """
 internet
 @enum Action search
@@ -40,7 +40,7 @@ end
 @doc "Search in internet: start search engine and automatically change to type command waiting for search keywords to be spoken."
 function search_internet()
     DefaultApplication.open(SEARCH_ENGINE)
-    Keyboard.type(Keyboard.words)
+    Keyboard.type(Keyboard.text)
 end
 
 end # module Internet

--- a/src/Commands/Keyboard.jl
+++ b/src/Commands/Keyboard.jl
@@ -24,7 +24,7 @@ import ..JustSayIt: @voiceargs, pyimport_pip, controller, set_controller, TYPE_M
 const Pynput = PyNULL()
 
 function __init__()
-    ENV["PYTHON"] = ""                                              # FORCE PyCall to use Conda.jl
+    ENV["PYTHON"] = ""                                              # Force PyCall to use Conda.jl
     copy!(Pynput, pyimport_pip("pynput"))
     set_controller("keyboard", Pynput.keyboard.Controller())
 end

--- a/src/Commands/Mouse.jl
+++ b/src/Commands/Mouse.jl
@@ -27,7 +27,7 @@ import ..JustSayIt: @voiceargs, pyimport_pip, controller, set_controller
 const Pynput = PyNULL()
 
 function __init__()
-    ENV["PYTHON"] = ""                                              # FORCE PyCall to use Conda.jl
+    ENV["PYTHON"] = ""                                              # Force PyCall to use Conda.jl
     copy!(Pynput, pyimport_pip("pynput"))
     set_controller("mouse", Pynput.mouse.Controller())
 end

--- a/src/JustSayIt.jl
+++ b/src/JustSayIt.jl
@@ -20,7 +20,6 @@ Type `?just_say_it` to learn about customization keywords.
 - [`@voiceargs`](@ref)
 
 #### Functions
-- [`just_say_it`](@ref)
 - [`init_jsi`](@ref)
 - [`finalize_jsi`](@ref)
 - [`is_next`](@ref)

--- a/src/just_say_it.jl
+++ b/src/just_say_it.jl
@@ -131,6 +131,18 @@ function just_say_it(; modeldirs::Dict{String,String}=DEFAULT_MODELDIRS, noises:
     finalize_jsi()
 end
 
-@voiceargs words=>(valid_input=["just say it"], use_max_accuracy=true, vararg_timeout=2.0, vararg_max=3) function is_confirmed(words::String...)
+function is_confirmed()
+    try
+        _is_confirmed()
+    catch e
+        if isa(e, InsecureRecognitionException)
+            return false
+        else
+            rethrow(e)
+        end
+    end
+end
+
+@voiceargs words=>(valid_input=["just say it"], use_max_accuracy=true, vararg_timeout=2.0, vararg_max=3) function _is_confirmed(words::String...)
     return (join(words, " ") == "just say it")
 end

--- a/src/recorder.jl
+++ b/src/recorder.jl
@@ -1,7 +1,21 @@
 @doc """
     start_recording()
 
+!!! note "Advanced"
+        start_recording(<keyword arguments>)
+
 Start recording.
+
+# Arguments
+!!! note "Advanced keyword arguments"
+    - `audio_input_cmd::Cmd=nothing`: a command that returns an audio stream to replace the default audio recorder. The audio stream must fullfill the following properties: `samplerate=$SAMPLERATE`, `channels=$AUDIO_IN_CHANNELS` and `format=Int16` (signed 16-bit integer).
+
+# Examples
+```
+# Use a custom command to create the audio input stream - instead of the default recorder (the rate, channels and format must not be chosen different!)
+audio_input_cmd = `arecord --rate=$SAMPLERATE --channels=$AUDIO_IN_CHANNELS --format=S16_LE`
+just_say_it(audio_input_cmd=audio_input_cmd)
+```
 
 See also: [`stop_recording`](@ref)
 """
@@ -34,21 +48,35 @@ See also: [`pause_recording`](@ref)
 """
 restart_recording
 
+import Base: readbytes!, close
 let
-    global recorder, start_recording, stop_recording, pause_recording, restart_recording
-    _recorders::Dict{String, Base.Process}                 = Dict{String, Base.Process}()
-    _active_recorder_id::String                            = ""
-    recorder(id::String=DEFAULT_RECORDER_ID)::Base.Process = _recorders[id]
-    active_recorder_id()::String                           = (if (_active_recorder_id=="") error("no recorder is active.") end; return _active_recorder_id)
+    global recorder, start_recording, stop_recording, pause_recording, restart_recording, readbytes!, close
+    _recorders::Dict{String, Union{Base.Process,PyObject}}                 = Dict{String, Union{Base.Process,PyObject}}()
+    _active_recorder_id::String                                            = ""
+    recorder(id::String=DEFAULT_RECORDER_ID)::Union{Base.Process,PyObject} = _recorders[id]
+    active_recorder_id()::String                                           = (if (_active_recorder_id=="") error("no recorder is active.") end; return _active_recorder_id)
 
-    function start_recording(id::String=DEFAULT_RECORDER_ID)
-        _recorders[id] = open(`$RECORDER_BACKEND $RECORDER_ARGS`) # NOTE: here could be started multiple recorders.
+    function start_recording(id::String=DEFAULT_RECORDER_ID; audio_input_cmd::Union{Cmd,Nothing}=nothing) # NOTE: here could be started multiple recorders.
+        if !isnothing(audio_input_cmd)
+            _recorders[id] = open(audio_input_cmd)
+        else # Default recorder
+            _recorders[id] = Sounddevice.RawInputStream(samplerate=SAMPLERATE, channels=AUDIO_IN_CHANNELS, dtype=lowercase(string(AUDIO_ELTYPE)), blocksize=Int(AUDIO_READ_MAX/sizeof(AUDIO_ELTYPE)))
+            _recorders[id].start()
+        end
         _active_recorder_id = id
     end
 
     function stop_recording(id::String=DEFAULT_RECORDER_ID)
         close(_recorders[id])
     end
+
+    function readbytes!(stream::PyObject, b::AbstractVector{UInt8}, nb=length(b))
+        nb_frames = Int(nb/sizeof(AUDIO_ELTYPE))
+        b .= stream.read(nb_frames)[1]
+        return nb
+    end
+
+    close(stream::PyObject) = stream.close()
 
     pause_recording()   = (stop_recording(active_recorder_id()); return)
     restart_recording() = (start_recording(active_recorder_id()); return)

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -4,8 +4,9 @@ import MacroTools: splitdef, combinedef
 
 
 ## PYTHON MODULES
-const Vosk   = PyNULL()
-const Pynput = PyNULL()
+const Vosk        = PyNULL()
+const Pynput      = PyNULL()
+const Sounddevice = PyNULL()
 
 function __init__()
     ENV["PYTHON"] = ""                                              # FORCE PyCall to use Conda.jl
@@ -15,8 +16,9 @@ function __init__()
         @info "...rebuild completed. Restart Julia and JustSayIt."
         exit()
     end
-    copy!(Vosk,   pyimport_pip("vosk"))
-    copy!(Pynput, pyimport_pip("pynput"))
+    copy!(Vosk,        pyimport_pip("vosk"))
+    copy!(Pynput,      pyimport_pip("pynput"))
+    copy!(Sounddevice, pyimport_pip("sounddevice"))
 end
 
 

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -7,9 +7,10 @@ import MacroTools: splitdef, combinedef
 const Vosk        = PyNULL()
 const Pynput      = PyNULL()
 const Sounddevice = PyNULL()
+const Zipfile     = PyNULL()
 
 function __init__()
-    ENV["PYTHON"] = ""                                              # FORCE PyCall to use Conda.jl
+    ENV["PYTHON"] = ""                                              # Force PyCall to use Conda.jl
     if !any(startswith.(PyCall.python, DEPOT_PATH))                 # Rebuild of PyCall if it has not been built with Conda.jl
         @info "Rebuilding PyCall for using Julia Conda.jl..."
         Pkg.build("PyCall")
@@ -19,6 +20,7 @@ function __init__()
     copy!(Vosk,        pyimport_pip("vosk"))
     copy!(Pynput,      pyimport_pip("pynput"))
     copy!(Sounddevice, pyimport_pip("sounddevice"))
+    copy!(Zipfile,     pyimport("zipfile"))
 end
 
 
@@ -30,9 +32,6 @@ const AUDIO_ALLOC_GRANULARITY = 1024^2  #[bytes]
 const AUDIO_HISTORY_MIN = 1024^2        #[bytes]
 const AUDIO_ELTYPE = Int16
 const AUDIO_IN_CHANNELS = 1
-Base.ENDIAN_BOM == 0x04030201 || error("only little-endian is supported")
-const RECORDER_BACKEND = "arecord"
-const RECORDER_ARGS = ["--rate=$SAMPLERATE", "--channels=$AUDIO_IN_CHANNELS", "--format=S16_LE", "--quiet"] # (S16_LE: signed 16 bit little endian)
 const COMMAND_NAME_EXIT  = "terminus"
 const COMMAND_NAME_SLEEP = "sleep"
 const COMMAND_NAME_AWAKE = "awake"
@@ -47,8 +46,15 @@ const NOISES_ENGLISH = ["huh"]
 const DIGITS_ENGLISH = Dict("zero"=>"0", "one"=>"1", "two"=>"2", "three"=>"3", "four"=>"4", "five"=>"5", "six"=>"6", "seven"=>"7", "eight"=>"8", "nine"=>"9", "dot"=>".")
 const UNKNOWN_TOKEN = "[unk]"
 
-const DEFAULT_MODELDIRS = Dict(DEFAULT_MODEL_NAME => "$(homedir())/.config/JustSayIt/models/vosk-model-small-en-us-0.15",
-                               TYPE_MODEL_NAME    => "$(homedir())/.config/JustSayIt/models/vosk-model-en-us-daanzu-20200905")
+@static if Sys.iswindows()
+    const MODELDIR_PREFIX = joinpath(ENV["APPDATA"], "JustSayIt", "models")
+elseif Sys.isapple()
+    const MODELDIR_PREFIX = joinpath(homedir(), "Library", "JustSayIt", "models")
+else
+    const MODELDIR_PREFIX = joinpath(homedir(), ".local", "share", "JustSayIt", "models")
+end
+const DEFAULT_MODELDIRS = Dict(DEFAULT_MODEL_NAME => joinpath(MODELDIR_PREFIX, "vosk-model-small-en-us-0.15"),
+                               TYPE_MODEL_NAME    => joinpath(MODELDIR_PREFIX, "vosk-model-en-us-daanzu-20200905"))
 const DEFAULT_NOISES    = Dict(DEFAULT_MODEL_NAME => NOISES_ENGLISH,
                                TYPE_MODEL_NAME    => NOISES_ENGLISH)
 


### PR DESCRIPTION
This PR makes the following portable:
- recording
- unzip
- default language model paths

In addition, it includes:
- a considerable improvement of the documentation
- a new `just_say_it` keyword argument `audio_input_cmd`.

Fixes #14 , #15