### PR TITLE
Add `include_config` function to conveniently include scripts to start JustSayIt and/or custom command functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ JustSayIt commands map to regular Julia functions. Function arguments can be eas
       return
   end
 ```
+Detailed information on `@voiceargs` is obtainable by typing `?@voiceargs`.
 
 While contributions to the JustSayIt command modules are very much encouraged, it is possible to quickly define and use custom `@voiceargs` functions thanks to the API of JustSayIt (`JustSayIt.API`). The following example shows how 1) a weather forecast search function (`weather`) can be programmed, 2) a command name to function mapping defined, and then 3) JustSayIt started using these customly defined commands. The command `weather` programmed here allows to find out how the weather is `today` or `tomorrow` - just say "weather today" or "weather tomorrow". Furthermore, if you say "help weather", it will show in the Julia REPL the function documentation written here. To run this example, type in the Julia REPL `include("path-to-file")` or simply copy-paste the code below inside (the corresponding file can be found [here](config_examples/config_custom_function.jl)).
 
@@ -169,6 +170,9 @@ commands = Dict("help"      => Help.help,
 # 3) Start JustSayIt with the custom commands.
 start(commands=commands)
 ```
+More information on the JustSayIt API is obtainable by typing `?JustSayIt.API`.
+
+Note that the JustSayIt application config folder (e.g., `~/.config/JustSayIt` on Unix systems) is an easily accessible storage for scripts to start JustSayIt and/or for custom command functions: `include_config` permits to conveniently `include` files from this folder. More information is obtainable by typing `?include_config`.
 
 ## Module documentation callable from the Julia REPL / IJulia
 The module documentation can be called from the [Julia REPL] or in [IJulia]:

--- a/src/JustSayIt.jl
+++ b/src/JustSayIt.jl
@@ -37,6 +37,7 @@ include("voiceargs.jl")
 include("finalize_jsi.jl")
 include("next_token.jl")
 include("init_jsi.jl")
+include("include_config.jl")
 include("recorder.jl")
 
 ## Include of command-submodules for peripherics control and help
@@ -53,7 +54,7 @@ include("start.jl")
 include("API.jl")
 
 ## Exports (need to be after include of submodules if re-exports from them)
-export start
+export start, include_config
 export Keyboard, Mouse, Help, Email, Internet
 export Key
 

--- a/src/include_config.jl
+++ b/src/include_config.jl
@@ -1,0 +1,15 @@
+"""
+    include_config(path::AbstractString)
+
+Prefix `path` with the JustSayIt application config path and then call `include(path)`. If `path` is an absolut path, then call `include` with `path` unmodified.
+
+!!! note "NOTE: JustSayIt application config"
+    The content of the JustSayIt application config folder is not evaluated within JustSayIt. The folder's single purpose is to provide an easily accessible storage for scripts to start JustSayIt and/or for custom command functions: `include_config` permits to conveniently `include` files from this folder (for details about the Julia built-in `include` type `?include`).
+    Your JustSayIt application config path on this system is: `$CONFIG_PREFIX`
+"""
+function include_config(path::AbstractString)
+    if !isabspath(path)
+        path = joinpath(CONFIG_PREFIX, path)
+    end
+    include(path)
+end

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -52,12 +52,18 @@ const UNKNOWN_TOKEN = "[unk]"
 const PyKey = Union{Char, PyObject}
 
 @static if Sys.iswindows()
-    const MODELDIR_PREFIX = joinpath(ENV["APPDATA"], "JustSayIt", "models")
+    const JSI_DATA        = joinpath(ENV["APPDATA"], "JustSayIt")
+    const MODELDIR_PREFIX = joinpath(JSI_DATA, "models")
+    const CONFIG_PREFIX   = joinpath(JSI_DATA, "config")
 elseif Sys.isapple()
-    const MODELDIR_PREFIX = joinpath(homedir(), "Library", "JustSayIt", "models")
+    const JSI_DATA        = joinpath(homedir(), "Library", "Application Support", "JustSayIt")
+    const MODELDIR_PREFIX = joinpath(JSI_DATA, "models")
+    const CONFIG_PREFIX   = joinpath(JSI_DATA, "config")
 else
     const MODELDIR_PREFIX = joinpath(homedir(), ".local", "share", "JustSayIt", "models")
+    const CONFIG_PREFIX   = joinpath(homedir(), ".config", "JustSayIt")
 end
+
 const DEFAULT_MODELDIRS = Dict(DEFAULT_MODEL_NAME => joinpath(MODELDIR_PREFIX, "vosk-model-small-en-us-0.15"),
                                TYPE_MODEL_NAME    => joinpath(MODELDIR_PREFIX, "vosk-model-en-us-daanzu-20200905"))
 const DEFAULT_NOISES    = Dict(DEFAULT_MODEL_NAME => NOISES_ENGLISH,


### PR DESCRIPTION
This PR includes a note in the README about `include_config`.