### PR TITLE
Improve spaces handling in typing text

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 
 [compat]

--- a/src/Commands/Keyboard.jl
+++ b/src/Commands/Keyboard.jl
@@ -55,8 +55,8 @@ Each of the modes supports a set of keywords which can trigger some immediate ac
 - "redo": redo typing of last word group.
 - "uppercase": type the first word of the next word group uppercase (automatic in `text` mode after '.', '!' and '?').
 - "lowercase": type the first word of the next word group lowercase (default).
-- "letters": interpret the next word group as letters.
-- "digits": interpret the next word group as digits (interprets in addition 'dot' as '.').
+- "letters": interpret the next word group as letters (interprets in addition 'space' as ' ').
+- "digits": interpret the next word group as digits (interprets in addition 'dot' as '.' and 'space' as ' ').
 - "point": type '.'.
 - "comma": type ','.
 - "colon": type ':'.

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -1,4 +1,4 @@
-import Pkg, Downloads
+import Pkg, Downloads, ProgressMeter
 using PyCall, Conda, JSON, MacroTools
 import MacroTools: splitdef, combinedef
 
@@ -46,8 +46,9 @@ const DEFAULT_RECORDER_ID = "default"
 const TYPE_MODEL_NAME = "type"
 const COMMAND_RECOGNIZER_ID = "" # NOTE: This is a safe ID as it cannot be taken by any model (raises error).
 const NOISES_ENGLISH = ["huh"]
-const DIGITS_ENGLISH = Dict("zero"=>"0", "one"=>"1", "two"=>"2", "three"=>"3", "four"=>"4", "five"=>"5", "six"=>"6", "seven"=>"7", "eight"=>"8", "nine"=>"9", "dot"=>".")
-const ALPHABET_ENGLISH = Dict("a"=>"a", "b"=>"b", "c"=>"c", "d"=>"d", "e"=>"e", "f"=>"f", "g"=>"g", "h"=>"h", "i"=>"i", "j"=>"j", "k"=>"k", "l"=>"l", "m"=>"m", "n"=>"n", "o"=>"o", "p"=>"p", "q"=>"q", "r"=>"r", "s"=>"s", "t"=>"t", "u"=>"u", "v"=>"v", "w"=>"w", "x"=>"x", "y"=>"y", "z"=>"z")
+const DIGITS_ENGLISH = Dict("zero"=>"0", "one"=>"1", "two"=>"2", "three"=>"3", "four"=>"4", "five"=>"5", "six"=>"6", "seven"=>"7", "eight"=>"8", "nine"=>"9", "dot"=>".", "space"=>" ")
+const ALPHABET_ENGLISH = Dict("a"=>"a", "b"=>"b", "c"=>"c", "d"=>"d", "e"=>"e", "f"=>"f", "g"=>"g", "h"=>"h", "i"=>"i", "j"=>"j", "k"=>"k", "l"=>"l", "m"=>"m", "n"=>"n", "o"=>"o", "p"=>"p", "q"=>"q", "r"=>"r", "s"=>"s", "t"=>"t", "u"=>"u", "v"=>"v", "w"=>"w", "x"=>"x", "y"=>"y", "z"=>"z", "space"=>" ")
+
 const UNKNOWN_TOKEN = "[unk]"
 const PyKey = Union{Char, PyObject}
 


### PR DESCRIPTION
Improvements in spaces handling (closes #39):
- no space is automatically added after a new paragraph ('paragraph' keyword)
- no space is automatically added before digits and letters
- the uppercase/lowercase keywords are also honoured for letters
- digits and letters mode supports newly 'space' (interpreted as ' ')

This PR adds in a addition a progress bar for the automatic model downloads (closes #29).
