### PR TITLE
Change default behaviour from max speed to max accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Finally, JustSayIt puts a small load on the CPU, using only one core, and can th
 
 ## Quick start
 1. Install [Julia] if you do not have it yet.
-2. Execute the following in your shell to install and run JustSayIt:
+2. Connect your best microphone (a good recording quality is key to a great voice control experience!)
+3. Execute the following in your shell to install and run JustSayIt:
 ```julia-repl
 $> julia
 julia> ]
@@ -31,7 +32,8 @@ julia> ]
 julia> using JustSayIt
 julia> start()
 ```
-3. Say "help commands" and then, e.g., "help type".
+4. Say "help commands" and then, e.g., "help type".
+5. Try some commands and then look through the documentation!
 
 ## User definable mapping of command names to functions or keyboard shortcuts
 The keyword `commands` of `start` enables to freely define a mapping of command names to functions or keyboard shortcuts, e.g.:
@@ -67,7 +69,7 @@ More information on customization keywords is obtainable by typing `?start`.
 
 ## Per command choice between maximum speed or accuracy
 
-The keyword `max_accuracy_subset` of `start` enables to define a subset of the `commands` for which the command names are to be recognised with maxium accuracy rather than with maximum speed, e.g.:
+The keyword `max_speed_subset` of `start` enables to define a subset of the `commands` for which the command names are to be recognised with maxium speed rather than with maximum accuracy, e.g.:
 ```julia-repl
 # Define custom commands
 using JustSayIt
@@ -79,9 +81,9 @@ commands = Dict("copy"      => (Key.ctrl, 'c'),
                 "upwards"   => Key.page_up,
                 "downwards" => Key.page_down,
                 );
-start(commands=commands, max_accuracy_subset=["cut", "paste", "undo", "redo"])
+start(commands=commands, max_speed_subset=["upwards", "downwards", "copy"])
 ```
-Forcing maximum accuracy is only sometimes needed for single word commands that map to keyboard shortcuts triggering immediate "dangerous" actions, like "cut", "paste", "undo" and "redo" in the above example (however, "copy", "upwards" and "downwards" do not modify content and can therefore safely be triggered at maximum speed). Note that forcing maximum accuracy means to wait for a certain amount of silence after the end of a command, which will be perceived as latency between the saying of a command name and its execution. Alternatively to forcing maximum accuracy for commands that map keyboard shortcuts, it is possible to define very distinctive command names, which allow for a safe command name to shortcut mapping at maximum speed (to be tested case by case).
+Forcing maximum speed is usually desired for single word commands that map to functions or keyboard shortcuts that should trigger immediate actions as, e.g., mouse clicks or, as in the above example page up/down or copy (in general, actions that do not modify content and can therefore safely be triggered at maximum speed). However, it is typically not desired for "dangerous" actions, like "cut", "paste", "undo" and "redo" in this example. Note that forcing maximum speed means not to wait for a certain amount of silence after the end of a command as normally done for the full confirmation of a recognition. As a result, it enables a minimal latency between the saying of a command name and its execution. Note that it is usually possible to define very distinctive command names, which allow for a safe command name to shortcut mapping at maximum speed (to be tested case by case).
 
 Note furthermore that a good recording quality is important in order to achieve a good recognition accuracy. In particular, background noise might reduce recognition accuracy. Thus, a microphone integrated in a notebook or a webcam might potentially lead to unsatisfying accuracy, while a headset or an external microphone that is well set up should lead to good accuracy. JustSayIt relying on the [Vosk Speech Recognition Toolkit], it is the latter that dictates the requirements on recording quality for good recognition accuracy (for more information, have a look at the subsection [accuracy](https://alphacephei.com/vosk/accuracy) on their website).
 
@@ -122,6 +124,7 @@ Saying "sleep JustSayIt" puts JustSayIt to sleep. It will not execute any comman
 
 ## Fast command programming with voice argument functions
 JustSayIt commands map to regular Julia functions. Function arguments can be easily passed by voice thanks to the `@voiceargs` macro. It allows to declare arguments in standard function definitions to be directly obtainable by voice. It, furthermore, allows to define speech recognition parameters for each voice argument as, e.g., the valid speech input. The following shows some examples:
+
 ```julia
   @voiceargs (b, c) function f(a, b::String, c::String, d)
       #(...)
@@ -129,17 +132,17 @@ JustSayIt commands map to regular Julia functions. Function arguments can be eas
   end
 ```
 ```julia
-  @voiceargs (b, c=>(use_max_accuracy=true)) function f(a, b::String, c::String, d)
-      #(...)
-      return
-  end
+    @voiceargs (b=>(use_max_speed=true), c) function f(a, b::String, c::String, d)
+        #(...)
+        return
+    end
 ```
 ```julia
-  @enum TypeMode words formula
-  @voiceargs (mode=>(valid_input_auto=true), token=>(model=TYPE_MODEL_NAME, use_max_accuracy=true, vararg_timeout=2.0)) function type_tokens(mode::TypeMode, tokens::String...)
-      #(...)
-      return
-  end
+    @enum TypeMode words formula
+    @voiceargs (mode=>(valid_input_auto=true), token=>(model=TYPE_MODEL_NAME, vararg_timeout=2.0)) function type_tokens(mode::TypeMode, tokens::String...)
+        #(...)
+        return
+    end
 ```
 Detailed information on `@voiceargs` is obtainable by typing `?@voiceargs`.
 

--- a/config_examples/config_custom_function.jl
+++ b/config_examples/config_custom_function.jl
@@ -11,7 +11,7 @@ Find out how the weather is `today` or `tomorrow`.
 """
 weather
 @enum Day today tomorrow
-@voiceargs day=>(valid_input_auto=true, use_max_accuracy=true) function weather(day::Day)
+@voiceargs day=>(valid_input_auto=true) function weather(day::Day)
     DefaultApplication.open("https://www.google.com/search?q=weather+$day")
 end
 

--- a/src/Commands/Email.jl
+++ b/src/Commands/Email.jl
@@ -32,7 +32,7 @@ Manage e-mails, performing one of the following actions:
 """
 email
 @enum Action inbox outbox
-@voiceargs action=>(valid_input_auto=true, use_max_accuracy=true) function email(action::Action)
+@voiceargs action=>(valid_input_auto=true) function email(action::Action)
     if     (action == inbox)  open_inbox()
     elseif (action == outbox) open_outbox()
     else                      @info "unknown action"  #NOTE: this should never happen.

--- a/src/Commands/Internet.jl
+++ b/src/Commands/Internet.jl
@@ -31,7 +31,7 @@ Navigate the internet, performing one of the following actions:
 """
 internet
 @enum Action search
-@voiceargs action=>(valid_input_auto=true, use_max_accuracy=true) function internet(action::Action)
+@voiceargs action=>(valid_input_auto=true) function internet(action::Action)
     if (action == search) search_internet()
     else @info "unknown action" #NOTE: this should never happen.
     end

--- a/src/Commands/Keyboard.jl
+++ b/src/Commands/Keyboard.jl
@@ -132,7 +132,7 @@ type
         end
         if is_new_group && (tokengroup_kind == undefined_kind)
             reset_all(; hard=true, exclude_active=true)      # NOTE: a reset is required to avoid that the dynamic recognizers generated in is_next and are_next include the previous recognition as desired for normal command recognition.
-            if is_next(type_keywords; use_max_accuracy=false, ignore_unknown=false)
+            if is_next(type_keywords; use_max_speed=true, ignore_unknown=false)
                 keywords = String[]
                 try
                     are_keywords, keywords = are_next(type_keywords; consume_if_match=true, ignore_unknown=false)
@@ -304,15 +304,15 @@ interpret_digits(input::AbstractString)  = (return DIGITS_ENGLISH[input])
 
 @doc "Get next word from speech."
 next_word
-@voiceargs word=>(model=TYPE_MODEL_NAME, use_max_accuracy=true) next_word(word::String) = (return word)
+@voiceargs word=>(model=TYPE_MODEL_NAME) next_word(word::String) = (return word)
 
 @doc "Get next letter from speech."
 next_letter
-@voiceargs letter=>(valid_input=[keys(ALPHABET_ENGLISH)...], use_max_accuracy=true, interpret_function=interpret_letters) next_letter(letter::String) = (return letter)
+@voiceargs letter=>(valid_input=[keys(ALPHABET_ENGLISH)...], interpret_function=interpret_letters) next_letter(letter::String) = (return letter)
 
 @doc "Get next digit from speech."
 next_digit
-@voiceargs digit=>(valid_input=[keys(DIGITS_ENGLISH)...], use_max_accuracy=true, interpret_function=interpret_digits) next_digit(digit::String) = (return digit)
+@voiceargs digit=>(valid_input=[keys(DIGITS_ENGLISH)...], interpret_function=interpret_digits) next_digit(digit::String) = (return digit)
 
 function type_backspace(; count::Integer=1)
     keyboard  = controller("keyboard")

--- a/src/next_token.jl
+++ b/src/next_token.jl
@@ -12,7 +12,7 @@ Check if the next token in the speech matches `token`; if yes, return `true`, el
 	- `modelname::String=DEFAULT_MODEL_NAME`: the name of the model to be used for the recognition in the token comparison (the name must be one of the keys of the modeldirs dictionary passed to `init_jsi`).
 	- `consume_if_match::Bool=false`: whether the next token is to be consumed in case of a match.
 	- `timeout::Float64=Inf`: timeout after which to abort waiting for a next token to be spoken.
-	- `use_max_accuracy::Bool=false`: whether to use maxium accuracy for the recognition of the next token (rather than maximum speed). It is only recommended to set `use_max_accuracy=true` if the next cluster of tokens is in any case to be recognised with maxium accuracy (typically used with a free speech recognizer, i.e. with a large vocabulary),
+	- `use_max_speed::Bool=false`: whether to use maxium speed for the recognition of the next token (rather than maximum accuracy). It is generally only recommended to set `use_max_speed=true` for single word commands or very specfic use cases that require immediate minimal latency action when a command is said.
 
 See also: [`init_jsi`](@ref)
 """
@@ -32,7 +32,7 @@ Check if the next group of tokens in the speech match `token`; if all match, ret
 	- `modelname::String=DEFAULT_MODEL_NAME`: the name of the model to be used for the recognition in the token comparison (the name must be one of the keys of the modeldirs dictionary passed to `init_jsi`).
 	- `consume_if_match::Bool=false`: whether the next token is to be consumed in case of a match.
 	- `timeout::Float64=Inf`: timeout after which to abort waiting for a next token to be spoken.
-	- `use_max_accuracy::Bool=false`: whether to use maxium accuracy for the recognition of the next token (rather than maximum speed). It is only recommended to set `use_max_accuracy=true` if the next cluster of tokens is in any case to be recognised with maxium accuracy (typically used with a free speech recognizer, i.e. with a large vocabulary),
+	- `use_max_speed::Bool=false`: whether to use maxium speed for the recognition of the next token (rather than maximum accuracy). It is generally only recommended to set `use_max_speed=true` for single word commands or very specfic use cases that require immediate minimal latency action when a command is said.
 
 See also: [`init_jsi`](@ref)
 """
@@ -134,14 +134,14 @@ let
 		return is_match
 	end
 
-	function is_next(token::Union{String,AbstractArray{String}}, valid_input::AbstractArray{String}; modelname::String=DEFAULT_MODEL_NAME, noise_tokens::AbstractArray{String}=noises(modelname), consume_if_match::Bool=false, timeout::Float64=Inf, use_max_accuracy::Bool=true, ignore_unknown::Bool=false)
+	function is_next(token::Union{String,AbstractArray{String}}, valid_input::AbstractArray{String}; modelname::String=DEFAULT_MODEL_NAME, noise_tokens::AbstractArray{String}=noises(modelname), consume_if_match::Bool=false, timeout::Float64=Inf, use_max_speed::Bool=false, ignore_unknown::Bool=false)
 		recognizer_info = (Symbol(), Symbol(), valid_input, modelname)
-		_is_next(token, recognizer_info, noise_tokens; consume_if_match=consume_if_match, timeout=timeout, use_partial_recognitions=!use_max_accuracy, force_dynamic_recognizer=true, ignore_unknown=ignore_unknown)
+		_is_next(token, recognizer_info, noise_tokens; consume_if_match=consume_if_match, timeout=timeout, use_partial_recognitions=use_max_speed, force_dynamic_recognizer=true, ignore_unknown=ignore_unknown)
 	end
 
-	function is_next(token::Union{String,AbstractArray{String}}; modelname::String=DEFAULT_MODEL_NAME, noise_tokens::AbstractArray{String}=noises(modelname), consume_if_match::Bool=false, timeout::Float64=Inf, use_max_accuracy::Bool=true, ignore_unknown::Bool=false)
+	function is_next(token::Union{String,AbstractArray{String}}; modelname::String=DEFAULT_MODEL_NAME, noise_tokens::AbstractArray{String}=noises(modelname), consume_if_match::Bool=false, timeout::Float64=Inf, use_max_speed::Bool=false, ignore_unknown::Bool=false)
 		valid_input = isa(token, String) ? [token] : token
-		is_next(token, valid_input; modelname=modelname, noise_tokens=noise_tokens, consume_if_match=consume_if_match, timeout=timeout, use_max_accuracy=use_max_accuracy, ignore_unknown=ignore_unknown)
+		is_next(token, valid_input; modelname=modelname, noise_tokens=noise_tokens, consume_if_match=consume_if_match, timeout=timeout, use_max_speed=use_max_speed, ignore_unknown=ignore_unknown)
 	end
 
 	#NOTE: this function will only consume the next tokens if `consume_if_match` is set true and all the tokens match.
@@ -169,14 +169,14 @@ let
 		return is_match, match
 	end
 
-	function are_next(token::Union{String,AbstractArray{String}}, valid_input::AbstractArray{String}; modelname::String=DEFAULT_MODEL_NAME, noise_tokens::AbstractArray{String}=noises(modelname), consume_if_match::Bool=false, timeout::Float64=Inf, use_max_accuracy::Bool=true, ignore_unknown::Bool=false)
+	function are_next(token::Union{String,AbstractArray{String}}, valid_input::AbstractArray{String}; modelname::String=DEFAULT_MODEL_NAME, noise_tokens::AbstractArray{String}=noises(modelname), consume_if_match::Bool=false, timeout::Float64=Inf, use_max_speed::Bool=false, ignore_unknown::Bool=false)
 		recognizer_info = (Symbol(), Symbol(), valid_input, modelname)
-		_are_next(token, recognizer_info, noise_tokens; consume_if_match=consume_if_match, timeout=timeout, use_partial_recognitions=!use_max_accuracy, force_dynamic_recognizer=true, ignore_unknown=ignore_unknown)
+		_are_next(token, recognizer_info, noise_tokens; consume_if_match=consume_if_match, timeout=timeout, use_partial_recognitions=use_max_speed, force_dynamic_recognizer=true, ignore_unknown=ignore_unknown)
 	end
 
-	function are_next(token::Union{String,AbstractArray{String}}; modelname::String=DEFAULT_MODEL_NAME, noise_tokens::AbstractArray{String}=noises(modelname), consume_if_match::Bool=false, timeout::Float64=Inf, use_max_accuracy::Bool=true, ignore_unknown::Bool=false)
+	function are_next(token::Union{String,AbstractArray{String}}; modelname::String=DEFAULT_MODEL_NAME, noise_tokens::AbstractArray{String}=noises(modelname), consume_if_match::Bool=false, timeout::Float64=Inf, use_max_speed::Bool=false, ignore_unknown::Bool=false)
 		valid_input = isa(token, String) ? [token] : token
-		are_next(token, valid_input; modelname=modelname, noise_tokens=noise_tokens, consume_if_match=consume_if_match, timeout=timeout, use_max_accuracy=use_max_accuracy, ignore_unknown=ignore_unknown)
+		are_next(token, valid_input; modelname=modelname, noise_tokens=noise_tokens, consume_if_match=consume_if_match, timeout=timeout, use_max_speed=use_max_speed, ignore_unknown=ignore_unknown)
 	end
 
 	# Create dynamically a recognizer based on the valid input, model and the consumed tokens recognised in the current audio_buffer.

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -39,7 +39,7 @@ const COMMAND_NAME_SLEEP = "sleep"
 const COMMAND_NAME_AWAKE = "awake"
 const COMMAND_ABORT = "abortus"
 const VARARG_END = "terminus"
-const VALID_VOICEARGS_KWARGS = Dict(:model=>String, :valid_input=>AbstractArray{String}, :valid_input_auto=>Bool, :interpret_function=>Function, :use_max_accuracy=>Bool, :vararg_end=>String, :vararg_max=>Integer, :vararg_timeout=>AbstractFloat)
+const VALID_VOICEARGS_KWARGS = Dict(:model=>String, :valid_input=>AbstractArray{String}, :valid_input_auto=>Bool, :interpret_function=>Function, :use_max_speed=>Bool, :vararg_end=>String, :vararg_max=>Integer, :vararg_timeout=>AbstractFloat)
 const DEFAULT_MODEL_NAME = "default"
 const DEFAULT_RECORDER_ID = "default"
 const TYPE_MODEL_NAME = "type"

--- a/src/voiceargs.jl
+++ b/src/voiceargs.jl
@@ -11,7 +11,7 @@ Declare some or all arguments of the `function` definition to be arguments that 
     - `valid_input::AbstractArray{String}`: the valid speech input (e.g. `["up", "down"]`).
     - `valid_input_auto::Bool`: whether the valid speech input can automatically be derived from the type of the function argument.
     - `interpret_function::Function`: a function to interpret the token (mapping a String to a different String).
-    - `use_max_accuracy::Bool=false`: whether to use maxium accuracy for the recognition of the function argument (rather than maximum speed). It is only recommended to set it to true if the next cluster of tokens is in any case to be recognised with maxium accuracy (typically used with a free speech recognizer, i.e. with a large vocabulary),
+    - `use_max_speed::Bool=false`: whether to use maxium speed for the recognition of the next token (rather than maximum accuracy). It is generally only recommended to set `use_max_speed=true` for single word commands or very specfic use cases that require immediate minimal latency action when a command is said.
     - `vararg_end::String`: a token to signal the end of a vararg (only valid if the function argument is a vararg).
     - `vararg_max::Integer=∞`: the maximum number of arguments the vararg can contain (only valid if the function argument is a vararg).
     - `vararg_timeout::AbstractFloat`: timeout after which to abort waiting for a next token to be spoken (only valid if the function argument is a vararg).
@@ -23,13 +23,13 @@ Declare some or all arguments of the `function` definition to be arguments that 
     return
 end
 
-@voiceargs (b, c=>(use_max_accuracy=true)) function f(a, b::String, c::String, d)
+@voiceargs (b=>(use_max_speed=true), c) function f(a, b::String, c::String, d)
     #(...)
     return
 end
 
 @enum TypeMode words formula
-@voiceargs (mode=>(valid_input_auto=true), token=>(model=TYPE_MODEL_NAME, use_max_accuracy=true, vararg_timeout=2.0)) function type_tokens(mode::TypeMode, tokens::String...)
+@voiceargs (mode=>(valid_input_auto=true), token=>(model=TYPE_MODEL_NAME, vararg_timeout=2.0)) function type_tokens(mode::TypeMode, tokens::String...)
     #(...)
     return
 end
@@ -202,7 +202,7 @@ function wrap_f(f_name, f_args, f_expr, voiceargs)
     for voicearg in keys(voiceargs)
         kwargs                   = voiceargs[voicearg]
         modelname                = haskey(kwargs,:model) ? kwargs[:model] : DEFAULT_MODEL_NAME
-        use_partial_recognitions = haskey(kwargs,:use_max_accuracy) ? !(kwargs[:use_max_accuracy]) : USE_PARTIAL_RECOGNITIONS_DEFAULT
+        use_partial_recognitions = haskey(kwargs,:use_max_speed) ? kwargs[:use_max_speed] : USE_PARTIAL_RECOGNITIONS_DEFAULT
         f_arg                    = f_args[voicearg]
         f_name_sym               = :(Symbol($(string(f_name))))
         voicearg_sym             = :(Symbol($(string(voicearg))))


### PR DESCRIPTION
This PR removes package-wide the kwargs `use_max_accuracy` and `max_accuracy_subset` and replaces them with the inverse kwargs  `use_speed_accuracy` and `max_speed_subset`

Closes #44 