### PR TITLE
Abort instead of ignore in case of unexpected voice input

### DIFF
--- a/src/Commands/Help.jl
+++ b/src/Commands/Help.jl
@@ -10,7 +10,7 @@ To see a description of a function type `?<functionname>`.
 """
 module Help
 
-import ..JustSayIt: @voiceargs, TYPE_MODEL_NAME, command, command_names, next_token, pretty_cmd_string, PyKey
+import ..JustSayIt: command, command_names, next_token, pretty_cmd_string, PyKey
 
 const COMMANDS_KEYWORD = "commands"
 

--- a/src/Commands/Keyboard.jl
+++ b/src/Commands/Keyboard.jl
@@ -306,15 +306,15 @@ interpret_digits(input::AbstractString)  = (return DIGITS_ENGLISH[input])
 
 @doc "Get next word from speech."
 next_word
-@voiceargs word=>(model=TYPE_MODEL_NAME) next_word(word::String) = (return word)
+@voiceargs word=>(model=TYPE_MODEL_NAME, ignore_unknown=true) next_word(word::String) = (return word)
 
 @doc "Get next letter from speech."
 next_letter
-@voiceargs letter=>(valid_input=[keys(ALPHABET_ENGLISH)...], interpret_function=interpret_letters) next_letter(letter::String) = (return letter)
+@voiceargs letter=>(valid_input=[keys(ALPHABET_ENGLISH)...], interpret_function=interpret_letters, ignore_unknown=true) next_letter(letter::String) = (return letter)
 
 @doc "Get next digit from speech."
 next_digit
-@voiceargs digit=>(valid_input=[keys(DIGITS_ENGLISH)...], interpret_function=interpret_digits) next_digit(digit::String) = (return digit)
+@voiceargs digit=>(valid_input=[keys(DIGITS_ENGLISH)...], interpret_function=interpret_digits, ignore_unknown=true) next_digit(digit::String) = (return digit)
 
 function type_string(str::String; do_keystrokes::Bool=true)
     if do_keystrokes

--- a/src/Commands/Mouse.jl
+++ b/src/Commands/Mouse.jl
@@ -19,7 +19,7 @@ To see a description of a function type `?<functionname>`.
 module Mouse
 
 using PyCall
-import ..JustSayIt: @voiceargs, pyimport_pip, controller, set_controller
+import ..JustSayIt: pyimport_pip, controller, set_controller
 
 
 ## PYTHON MODULES

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -51,7 +51,7 @@ const COMMAND_NAME_SLEEP = "sleep"
 const COMMAND_NAME_AWAKE = "awake"
 const COMMAND_ABORT = "abortus"
 const VARARG_END = "terminus"
-const VALID_VOICEARGS_KWARGS = Dict(:model=>String, :valid_input=>AbstractArray{String}, :valid_input_auto=>Bool, :interpret_function=>Function, :use_max_speed=>Bool, :vararg_end=>String, :vararg_max=>Integer, :vararg_timeout=>AbstractFloat)
+const VALID_VOICEARGS_KWARGS = Dict(:model=>String, :valid_input=>AbstractArray{String}, :valid_input_auto=>Bool, :interpret_function=>Function, :use_max_speed=>Bool, :vararg_end=>String, :vararg_max=>Integer, :vararg_timeout=>AbstractFloat, :ignore_unknown=>Bool)
 const DEFAULT_MODEL_NAME = "default"
 const DEFAULT_RECORDER_ID = "default"
 const DEFAULT_READER_ID = "default"

--- a/test/test_voiceargs.jl
+++ b/test/test_voiceargs.jl
@@ -15,7 +15,7 @@ import JustSayIt: voicearg_f_names, voiceargs, recognizer
 @voiceargs (
     nr=>(valid_input=[keys(DIGITS_ENGLISH)...], interpret_function=Keyboard.interpret_digits, use_max_speed=true),
     name=>(valid_input_auto=true),
-    question=>(model=TYPE_MODEL_NAME, vararg_end="end", vararg_max=10, vararg_timeout=5.0)
+    question=>(model=TYPE_MODEL_NAME, ignore_unknown=true, vararg_end="end", vararg_max=10, vararg_timeout=5.0)
 ) function ask(nr::Integer, name::Name, question::String...)
     println("[Q$nr] Hi $name, could you please $(join(question," "))?")
 end
@@ -45,7 +45,7 @@ init_jsi(commands, modeldirs, DEFAULT_NOISES)
             @test issetequal(keys(voiceargs(:hi)[:n2]), [:recognizer, :valid_input, :valid_input_auto])
             @test issetequal(keys(voiceargs(:ask)[:nr]), [:recognizer, :valid_input, :interpret_function, :use_max_speed])
             @test issetequal(keys(voiceargs(:ask)[:name]), [:recognizer, :valid_input, :valid_input_auto])
-            @test issetequal(keys(voiceargs(:ask)[:question]), [:model, :vararg_end, :vararg_max, :vararg_timeout])
+            @test issetequal(keys(voiceargs(:ask)[:question]), [:model, :ignore_unknown, :vararg_end, :vararg_max, :vararg_timeout])
         end;
         @testset "kwarg content" begin
             @testset "recognizers" begin
@@ -72,6 +72,9 @@ init_jsi(commands, modeldirs, DEFAULT_NOISES)
             end;
             @testset "use_max_speed" begin
                 @test voiceargs(:ask)[:nr][:use_max_speed] == true
+            end;
+            @testset "ignore_unknown" begin
+                @test voiceargs(:ask)[:question][:ignore_unknown] == true
             end;
             @testset "model" begin
                 @test voiceargs(:ask)[:question][:model] == TYPE_MODEL_NAME


### PR DESCRIPTION
This PR changes the default behavior of `@voiceargs` with respect to the handling of unexpected voice input: abort instead of ignore.

Closes #58 