### PR TITLE
remove commands from max speed subset not present in command dictionary

### DIFF
--- a/paper/codes/noprogramming_example.jl
+++ b/paper/codes/noprogramming_example.jl
@@ -23,5 +23,4 @@ commands = Dict(
 start(commands=commands, 
       type_languages=["en-us", "fr"], 
       max_speed_subset=["ma", "middle", "right", 
-      "hold", "release", "page up", "page down", 
-      "take"])
+      "hold", "release", "take"])


### PR DESCRIPTION
Fixing revision comment:
> In Fig 2, a using JustSayIt.API is required (same goes for the documentation at https://omlins.github.io/JustSayIt.jl/stable/usage/

```
julia> using JustSayIt

julia> #1) Define mapping of command names to functions, 
       #   keyboard shortcuts and command sequences.
       commands = Dict(
           "help"      => Help.help,
           "type"      => Keyboard.type,
           "ma"        => Mouse.click_left,
           "middle"    => Mouse.click_middle,
           "right"     => Mouse.click_right,
           "hold"      => Mouse.press_left,
           "release"   => Mouse.release_left,
           "undo"      => (Key.ctrl, 'z'),
           "redo"      => (Key.ctrl, Key.shift, 'z'),
           "take"      => [Mouse.click_double, 
                           (Key.ctrl, 'c')],
           "replace"   => [Mouse.click_double, 
                           (Key.ctrl, 'v')]
           )
Dict{String, Any} with 11 entries:
  "replace" => Any[click_double, (PyObject <Key.ctrl: <65507>>, 'v')]
  "ma"      => click_left
  "undo"    => (PyObject <Key.ctrl: <65507>>, 'z')
  "take"    => Any[click_double, (PyObject <Key.ctrl: <65507>>, 'c')]
  "hold"    => press_left
  "middle"  => click_middle
  "release" => release_left
  "right"   => click_right
  "help"    => help
  "redo"    => (PyObject <Key.ctrl: <65507>>, PyObject <Key.shift: <65505>>, 'z')
  "type"    => type

julia> #2) Start JustSayIt, activating max speed 
       #   recognition for a subset of the commands.
       start(commands=commands, 
             type_languages=["en-us", "fr"], 
             max_speed_subset=["ma", "middle", "right", 
             "hold", "release", "take"])
[ Info: JustSayIt: I am initializing...
[ Info: Listening for commands in English (United States) (say "sleep JustSayIt" to put me to sleep; press CTRL+c to terminate)...

```